### PR TITLE
Add unescaping support

### DIFF
--- a/NextLevelSeven.Test/Core/EscapeFunctionalTestFixture.cs
+++ b/NextLevelSeven.Test/Core/EscapeFunctionalTestFixture.cs
@@ -155,7 +155,7 @@ namespace NextLevelSeven.Test.Core
         {
             // this contains what looks like the start of a variable length
             // locally defined sequence but is only partially existing.
-            Test_UnEscape("\\E\\Zork", "\\Zork");
+            Test_UnEscape("\\Zork", "\\E\\Zork");
         }
 
         [Test]

--- a/NextLevelSeven.Test/Core/EscapeFunctionalTestFixture.cs
+++ b/NextLevelSeven.Test/Core/EscapeFunctionalTestFixture.cs
@@ -36,13 +36,13 @@ namespace NextLevelSeven.Test.Core
             messageBuilder.Encoding.UnEscape(test).Should().Be(expected);
         }
 
-        private static void Test_SingleDelimiterUnEscape(string delimiter, string escapeCode)
+        private static void Test_SingleDelimiterUnEscape(string expectedCode, string sourceCode)
         {
             var leftString = Any.String();
             var middleString = Any.String();
             var rightString = Any.String();
-            var test = $"{leftString}{escapeCode}{middleString}{escapeCode}{rightString}";
-            var expected = $"{leftString}{delimiter}{middleString}{delimiter}{rightString}";
+            var test = $"{leftString}{sourceCode}{middleString}{sourceCode}{rightString}";
+            var expected = $"{leftString}{expectedCode}{middleString}{expectedCode}{rightString}";
             Test_UnEscape(expected, test);
         }
 
@@ -133,6 +133,12 @@ namespace NextLevelSeven.Test.Core
         }
         
         [Test]
+        public void Escape_Converts_BinaryData()
+        {
+            Test_SingleDelimiterEscape("\x0D\x0A", "\\X0D\\\\X0A\\");
+        }
+
+        [Test]
         public void UnEscape_Converts_ComponentCharacters()
         {
             Test_SingleDelimiterUnEscape("^", "\\S\\");
@@ -168,6 +174,12 @@ namespace NextLevelSeven.Test.Core
         public void UnEscape_Converts_SubcomponentCharacters()
         {
             Test_SingleDelimiterUnEscape("&", "\\T\\");
+        }
+
+        [Test]
+        public void UnEscape_Converts_BinaryData()
+        {
+            Test_SingleDelimiterUnEscape("\x0D\x0A", "\\X0D\\\\X0A\\");
         }
 
         [Test]

--- a/NextLevelSeven.Test/Core/EscapeFunctionalTestFixture.cs
+++ b/NextLevelSeven.Test/Core/EscapeFunctionalTestFixture.cs
@@ -23,9 +23,27 @@ namespace NextLevelSeven.Test.Core
             var leftString = Any.String();
             var middleString = Any.String();
             var rightString = Any.String();
-            var test = String.Format("{0}{3}{1}{3}{2}", leftString, middleString, rightString, delimiter);
-            var expected = string.Format("{0}{3}{1}{3}{2}", leftString, middleString, rightString, escapeCode);
+            var test = $"{leftString}{delimiter}{middleString}{delimiter}{rightString}";
+            var expected = $"{leftString}{escapeCode}{middleString}{escapeCode}{rightString}";
             Test_Escape(expected, test);
+        }
+
+        private static void Test_UnEscape(string expected, string test)
+        {
+            var messageParser = Message.Parse();
+            var messageBuilder = Message.Build();
+            messageParser.Encoding.UnEscape(test).Should().Be(expected);
+            messageBuilder.Encoding.UnEscape(test).Should().Be(expected);
+        }
+
+        private static void Test_SingleDelimiterUnEscape(string delimiter, string escapeCode)
+        {
+            var leftString = Any.String();
+            var middleString = Any.String();
+            var rightString = Any.String();
+            var test = $"{leftString}{escapeCode}{middleString}{escapeCode}{rightString}";
+            var expected = $"{leftString}{delimiter}{middleString}{delimiter}{rightString}";
+            Test_UnEscape(expected, test);
         }
 
         [Test]
@@ -75,43 +93,123 @@ namespace NextLevelSeven.Test.Core
         [Test]
         public void Escape_DoesNotConvert_HighlightTextMarker()
         {
-            var message = String.Format("{0}\\H\\{1}", Any.String(), Any.String());
+            var message = $"{Any.String()}\\H\\{Any.String()}";
             Test_Escape(message, message);
         }
 
         [Test]
         public void Escape_DoesNotConvert_NormalTextMarker()
         {
-            var message = String.Format("{0}\\N\\{1}", Any.String(), Any.String());
+            var message = $"{Any.String()}\\N\\{Any.String()}";
             Test_Escape(message, message);
         }
 
         [Test]
         public void Escape_DoesNotConvert_MultiByteCharacterSetLongEscapeSequence()
         {
-            var message = String.Format("{0}\\MABCDEF\\{1}", Any.String(), Any.String());
+            var message = $"{Any.String()}\\MABCDEF\\{Any.String()}";
             Test_Escape(message, message);
         }
 
         [Test]
         public void Escape_DoesNotConvert_MultiByteCharacterSetShortEscapeSequence()
         {
-            var message = String.Format("{0}\\MABCD\\{1}", Any.String(), Any.String());
+            var message = $"{Any.String()}\\MABCD\\{Any.String()}";
             Test_Escape(message, message);
         }
 
         [Test]
         public void Escape_DoesNotConvert_LocallyDefinedEscapeSequence()
         {
-            var message = String.Format("{0}\\Z{2}\\{1}", Any.String(), Any.String(), Any.String());
+            var message = $"{Any.String()}\\Z{Any.String()}\\{Any.String()}";
             Test_Escape(message, message);
         }
 
         [Test]
         public void Escape_DoesNotConvert_SingleByteCharacterSetEscapeSequence()
         {
-            var message = String.Format("{0}\\CABCD\\{1}", Any.String(), Any.String());
+            var message = $"{Any.String()}\\CABCD\\{Any.String()}";
             Test_Escape(message, message);
+        }
+        
+        [Test]
+        public void UnEscape_Converts_ComponentCharacters()
+        {
+            Test_SingleDelimiterUnEscape("^", "\\S\\");
+        }
+
+        [Test]
+        public void UnEscape_Converts_EscapeCharacters()
+        {
+            Test_SingleDelimiterUnEscape("\\", "\\E\\");
+        }
+
+        [Test]
+        public void UnEscape_Converts_FieldCharacters()
+        {
+            Test_SingleDelimiterUnEscape("|", "\\F\\");
+        }
+
+        [Test]
+        public void UnEscape_Converts_PartialEscapeSequences()
+        {
+            // this contains what looks like the start of a variable length
+            // locally defined sequence but is only partially existing.
+            Test_UnEscape("\\E\\Zork", "\\Zork");
+        }
+
+        [Test]
+        public void UnEscape_Converts_RepetitionCharacters()
+        {
+            Test_SingleDelimiterUnEscape("~", "\\R\\");
+        }
+
+        [Test]
+        public void UnEscape_Converts_SubcomponentCharacters()
+        {
+            Test_SingleDelimiterUnEscape("&", "\\T\\");
+        }
+
+        [Test]
+        public void UnEscape_DoesNotConvert_HighlightTextMarker()
+        {
+            var message = $"{Any.String()}\\H\\{Any.String()}";
+            Test_UnEscape(message, message);
+        }
+
+        [Test]
+        public void UnEscape_DoesNotConvert_NormalTextMarker()
+        {
+            var message = $"{Any.String()}\\N\\{Any.String()}";
+            Test_UnEscape(message, message);
+        }
+
+        [Test]
+        public void UnEscape_DoesNotConvert_MultiByteCharacterSetLongEscapeSequence()
+        {
+            var message = $"{Any.String()}\\MABCDEF\\{Any.String()}";
+            Test_UnEscape(message, message);
+        }
+
+        [Test]
+        public void UnEscape_DoesNotConvert_MultiByteCharacterSetShortEscapeSequence()
+        {
+            var message = $"{Any.String()}\\MABCD\\{Any.String()}";
+            Test_UnEscape(message, message);
+        }
+
+        [Test]
+        public void UnEscape_DoesNotConvert_LocallyDefinedEscapeSequence()
+        {
+            var message = $"{Any.String()}\\Z{Any.String()}\\{Any.String()}";
+            Test_UnEscape(message, message);
+        }
+
+        [Test]
+        public void UnEscape_DoesNotConvert_SingleByteCharacterSetEscapeSequence()
+        {
+            var message = $"{Any.String()}\\CABCD\\{Any.String()}";
+            Test_UnEscape(message, message);
         }
     }
 }

--- a/NextLevelSeven/Building/Elements/BuilderEncodingConfiguration.cs
+++ b/NextLevelSeven/Building/Elements/BuilderEncodingConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using NextLevelSeven.Core.Encoding;
 
 namespace NextLevelSeven.Building.Elements
@@ -46,33 +47,39 @@ namespace NextLevelSeven.Building.Elements
             set => _builder.SubcomponentDelimiter = value;
         }
 
+        public override Encoding CharacterEncoding
+        {
+            get => Msh18EncodingMap.GetEncoding(_builder.Message[18]?.Value);
+            [ExcludeFromCodeCoverage] protected set { }
+        }
+
         public override char ComponentDelimiter
         {
-            get { return _builder.ComponentDelimiter; }
+            get => _builder.ComponentDelimiter;
             [ExcludeFromCodeCoverage] protected set { }
         }
 
         public override char EscapeCharacter
         {
-            get { return _builder.EscapeCharacter; }
+            get => _builder.EscapeCharacter;
             [ExcludeFromCodeCoverage] protected set { }
         }
 
         public override char FieldDelimiter
         {
-            get { return _builder.FieldDelimiter; }
+            get => _builder.FieldDelimiter;
             [ExcludeFromCodeCoverage] protected set { }
         }
 
         public override char RepetitionDelimiter
         {
-            get { return _builder.RepetitionDelimiter; }
+            get => _builder.RepetitionDelimiter;
             [ExcludeFromCodeCoverage] protected set { }
         }
 
         public override char SubcomponentDelimiter
         {
-            get { return _builder.SubcomponentDelimiter; }
+            get => _builder.SubcomponentDelimiter;
             [ExcludeFromCodeCoverage] protected set { }
         }
     }

--- a/NextLevelSeven/Building/Elements/BuilderEncodingConfiguration.cs
+++ b/NextLevelSeven/Building/Elements/BuilderEncodingConfiguration.cs
@@ -49,7 +49,7 @@ namespace NextLevelSeven.Building.Elements
 
         public override Encoding CharacterEncoding
         {
-            get => Msh18EncodingMap.GetEncoding(_builder.Message[18]?.Value);
+            get => Msh18EncodingMap.GetEncoding(_builder?.Message?[18]?.Value);
             [ExcludeFromCodeCoverage] protected set { }
         }
 

--- a/NextLevelSeven/Core/Encoding/EncodingConfiguration.cs
+++ b/NextLevelSeven/Core/Encoding/EncodingConfiguration.cs
@@ -3,8 +3,9 @@
     internal sealed class EncodingConfiguration : ReadOnlyEncodingConfiguration, IEncoding
     {
         /// <summary>Create an encoding configuration with the default characters.</summary>
-        public EncodingConfiguration()
+        public EncodingConfiguration(System.Text.Encoding encoding = null)
         {
+            CharacterEncoding = encoding ?? System.Text.Encoding.UTF8;
         }
 
         /// <summary>Clone an existing encoding configuration.</summary>
@@ -28,6 +29,9 @@
 
         /// <summary>Get the subcomponent delimiter.</summary>
         public override char SubcomponentDelimiter { get; protected set; }
+        
+        /// <summary>Get the current character encoding.</summary>
+        public override System.Text.Encoding CharacterEncoding { get; protected set; }
 
         char IEncoding.ComponentDelimiter
         {

--- a/NextLevelSeven/Core/Encoding/EncodingOperations.cs
+++ b/NextLevelSeven/Core/Encoding/EncodingOperations.cs
@@ -176,8 +176,6 @@ namespace NextLevelSeven.Core.Encoding
             var repetitionDelimiter = new string(config.RepetitionDelimiter, 1);
             var subcomponentDelimiter = new string(config.SubcomponentDelimiter, 1);
 
-            var data = s.ToCharArray();
-            var length = data.Length;
             var output = new StringBuilder(s);
             var matches = escapeRegex.Matches(s);
 

--- a/NextLevelSeven/Core/Encoding/EncodingOperations.cs
+++ b/NextLevelSeven/Core/Encoding/EncodingOperations.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace NextLevelSeven.Core.Encoding
 {
@@ -161,26 +163,55 @@ namespace NextLevelSeven.Core.Encoding
         /// <returns>Unescaped string.</returns>
         public static string UnEscape(IReadOnlyEncoding config, string s)
         {
+            var escapeRegex = new Regex($"\\{config.EscapeCharacter}(E|F|R|S|T)*.\\{config.EscapeCharacter}");
+            
             if (s == null)
             {
                 return null;
             }
 
-            var componentDelimiter = config.ComponentDelimiter;
-            var escapeDelimiter = config.EscapeCharacter;
-            var fieldDelimiter = config.FieldDelimiter;
-            var repetitionDelimiter = config.RepetitionDelimiter;
-            var subcomponentDelimiter = config.SubcomponentDelimiter;
+            var componentDelimiter = new string(config.ComponentDelimiter, 1);
+            var escapeDelimiter = new string(config.EscapeCharacter, 1);
+            var fieldDelimiter = new string(config.FieldDelimiter, 1);
+            var repetitionDelimiter = new string(config.RepetitionDelimiter, 1);
+            var subcomponentDelimiter = new string(config.SubcomponentDelimiter, 1);
 
             var data = s.ToCharArray();
             var length = data.Length;
-            var output = new StringBuilder();
+            var output = new StringBuilder(s);
+            var matches = escapeRegex.Matches(s);
 
-            for (var index = 0; index < length; index++)
+            foreach (var match in matches.Cast<Match>().OrderByDescending(m => m.Index))
             {
+                var matchValue = match.Value;
+                var value = match.Value;
                 
-            }
+                switch (matchValue[1])
+                {
+                    case 'E':
+                        value = escapeDelimiter;
+                        break;
+                    case 'F':
+                        value = fieldDelimiter;
+                        break;
+                    case 'R':
+                        value = repetitionDelimiter;
+                        break;
+                    case 'S':
+                        value = componentDelimiter;
+                        break;
+                    case 'T':
+                        value = subcomponentDelimiter;
+                        break;
+                }
 
+                if (value != matchValue)
+                {
+                    output.Remove(match.Index, matchValue.Length);
+                    output.Insert(match.Index, value);
+                }
+            }
+            
             return output.ToString();
         }
     }

--- a/NextLevelSeven/Core/Encoding/EncodingOperations.cs
+++ b/NextLevelSeven/Core/Encoding/EncodingOperations.cs
@@ -161,7 +161,27 @@ namespace NextLevelSeven.Core.Encoding
         /// <returns>Unescaped string.</returns>
         public static string UnEscape(IReadOnlyEncoding config, string s)
         {
-            throw new NotImplementedException();
+            if (s == null)
+            {
+                return null;
+            }
+
+            var componentDelimiter = config.ComponentDelimiter;
+            var escapeDelimiter = config.EscapeCharacter;
+            var fieldDelimiter = config.FieldDelimiter;
+            var repetitionDelimiter = config.RepetitionDelimiter;
+            var subcomponentDelimiter = config.SubcomponentDelimiter;
+
+            var data = s.ToCharArray();
+            var length = data.Length;
+            var output = new StringBuilder();
+
+            for (var index = 0; index < length; index++)
+            {
+                
+            }
+
+            return output.ToString();
         }
     }
 }

--- a/NextLevelSeven/Core/Encoding/EncodingOperations.cs
+++ b/NextLevelSeven/Core/Encoding/EncodingOperations.cs
@@ -154,6 +154,12 @@ namespace NextLevelSeven.Core.Encoding
                     continue;
                 }
 
+                if (char.IsControl(c))
+                {
+                    output.Append(EscapeHexUtf8(config, new string(c, 1)));
+                    continue;
+                }
+
                 output.Append(c);
             }
 
@@ -163,11 +169,19 @@ namespace NextLevelSeven.Core.Encoding
         /// <summary>
         /// Escapes an X sequence. This currently assumes a UTF-8 encoding. TODO: other encodings
         /// </summary>
+        /// <param name="encoding">Encoding configuration.</param>
         /// <param name="value">Value to escape.</param>
         /// <returns>Unescaped string.</returns>
         private static string EscapeHexUtf8(IReadOnlyEncoding encoding, string value)
         {
             var output = new StringBuilder();
+            var enc = encoding.CharacterEncoding;
+
+            foreach (var c in enc.GetBytes(value))
+            {
+                output.Append(HexValues[c >> 4]);
+                output.Append(HexValues[c & 15]);
+            }
 
             return $"{encoding.EscapeCharacter}X{output}{encoding.EscapeCharacter}";
         }
@@ -205,7 +219,7 @@ namespace NextLevelSeven.Core.Encoding
         {
             var escapeCharacter = config.EscapeCharacter;
             var escapeRegex = new Regex($"(\\{escapeCharacter}(E|F|R|S|T)\\{escapeCharacter}|" +
-                                        $"\\{escapeCharacter}X*.\\{escapeCharacter})");
+                                        $"\\{escapeCharacter}X[^\\{escapeCharacter}]*\\{escapeCharacter})");
             
             if (s == null)
             {

--- a/NextLevelSeven/Core/Encoding/IReadOnlyEncoding.cs
+++ b/NextLevelSeven/Core/Encoding/IReadOnlyEncoding.cs
@@ -3,19 +3,22 @@
     /// <summary>Represents message-wide encoding characters.</summary>
     public interface IReadOnlyEncoding
     {
-        /// <summary>Get or set the character used to separate component-level content.</summary>
+        /// <summary>Get the character used to separate component-level content.</summary>
         char ComponentDelimiter { get; }
 
-        /// <summary>Get or set the character used to signify escape sequences.</summary>
+        /// <summary>Get the character used to signify escape sequences.</summary>
         char EscapeCharacter { get; }
 
-        /// <summary>Get or set the character used to separate fields.</summary>
+        /// <summary>Get the character used to separate fields.</summary>
         char FieldDelimiter { get; }
 
-        /// <summary>Get or set the character used to separate field repetition content.</summary>
+        /// <summary>Get the character used to separate field repetition content.</summary>
         char RepetitionDelimiter { get; }
 
-        /// <summary>Get or set the character used to separate subcomponent-level content.</summary>
+        /// <summary>Get the character used to separate subcomponent-level content.</summary>
         char SubcomponentDelimiter { get; }
+        
+        /// <summary>Get the current character encoding.</summary>
+        System.Text.Encoding CharacterEncoding { get; }
     }
 }

--- a/NextLevelSeven/Core/Encoding/Msh18EncodingMap.cs
+++ b/NextLevelSeven/Core/Encoding/Msh18EncodingMap.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace NextLevelSeven.Core.Encoding
+{
+    /// <summary>
+    /// Map between MSH-18 character encoding definitions and Windows code pages.
+    /// </summary>
+    internal static class Msh18EncodingMap
+    {
+        public static System.Text.Encoding GetEncoding(string name)
+        {
+            switch (name?.ToLowerInvariant())
+            {
+                case "iso ir14":
+                case "iso ir87":
+                case "iso ir159":
+                    return System.Text.Encoding.GetEncoding(20932);
+                case "8859/1":
+                    return System.Text.Encoding.GetEncoding(28591);
+                case "8859/2":
+                    return System.Text.Encoding.GetEncoding(28592);
+                case "8859/3":
+                    return System.Text.Encoding.GetEncoding(28593);
+                case "8859/4":
+                    return System.Text.Encoding.GetEncoding(28594);
+                case "8859/5":
+                    return System.Text.Encoding.GetEncoding(28595);
+                case "8859/6":
+                    return System.Text.Encoding.GetEncoding(28596);
+                case "8859/7":
+                    return System.Text.Encoding.GetEncoding(28597);
+                case "8859/8":
+                    return System.Text.Encoding.GetEncoding(28598);
+                case "8859/9":
+                    return System.Text.Encoding.GetEncoding(28599);
+                case "8859/15":
+                    return System.Text.Encoding.GetEncoding(28605);
+                default:
+                    return System.Text.Encoding.UTF8;
+            }
+        }
+
+        public static string GetName(System.Text.Encoding encoding)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/NextLevelSeven/Core/Encoding/ReadOnlyEncodingConfiguration.cs
+++ b/NextLevelSeven/Core/Encoding/ReadOnlyEncodingConfiguration.cs
@@ -23,6 +23,9 @@
 
         /// <summary>Get the delimiter character used to split subcomponents.</summary>
         public abstract char SubcomponentDelimiter { get; protected set; }
+        
+        /// <summary>Get the current character encoding.</summary>
+        public abstract System.Text.Encoding CharacterEncoding { get; protected set; }
 
         /// <summary>Clone defaults from another configuration.</summary>
         /// <param name="other">Source configuration.</param>

--- a/NextLevelSeven/Parsing/Elements/ParserEncodingConfiguration.cs
+++ b/NextLevelSeven/Parsing/Elements/ParserEncodingConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using NextLevelSeven.Core;
 using NextLevelSeven.Core.Encoding;
 
@@ -50,6 +51,12 @@ namespace NextLevelSeven.Parsing.Elements
         public override char SubcomponentDelimiter
         {
             get { return TryGetChar(_segment[2].Value, 3); }
+            [ExcludeFromCodeCoverage] protected set { }
+        }
+
+        public override Encoding CharacterEncoding
+        {
+            get => Msh18EncodingMap.GetEncoding(_segment[18]?.Value?.ToLowerInvariant());
             [ExcludeFromCodeCoverage] protected set { }
         }
 


### PR DESCRIPTION
This should be on the *path* to resolving #7.

Permanently resolving it will be a _breaking change_; `Value` on any fields currently will always return the original value without processing. Ideally, we would love for encoding and escaping to be transparent. Look for this permanent change in 2.0.

A new property called `RawValue` will do what `Value` does today.

Also, because encoding has been introduced, Escape/UnEscape will respect whatever encoding configuration is used in whichever Builder or Parser is being used.